### PR TITLE
Fix PATH being stomped by generated environment script

### DIFF
--- a/oebb.sh
+++ b/oebb.sh
@@ -153,9 +153,10 @@ else
     #--------------------------------------------------------------------------
     # Include up-to-date bitbake in our PATH.
     #--------------------------------------------------------------------------
-    export PATH=${OE_SOURCE_DIR}/openembedded-core/scripts:${OE_SOURCE_DIR}/bitbake/bin:${PATH}
+	OE_EXEC_PATH=${OE_SOURCE_DIR}/openembedded-core/scripts:${OE_SOURCE_DIR}/bitbake/bin
+    export PATH=${OE_EXEC_PATH}:${PATH}
 
-    echo "export PATH=\"${PATH}\"" >> ${OE_ENV_FILE}
+    echo "export PATH=${OE_EXEC_PATH}:\${PATH}" >> ${OE_ENV_FILE}
 
     #--------------------------------------------------------------------------
     # Make sure Bitbake doesn't filter out the following variables from our


### PR DESCRIPTION
Use the PATH variable in the generated environment script, rather than the current value of the PATH variable. This prevents later changes to a user's PATH from being stomped by the generated environment script.

This was tested using bash to run oebb.sh
