### PR TITLE
conf/local.conf: adjust DISTRO

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -20,7 +20,7 @@ NOISO = "1"
 PARALLEL_MAKE     = "-j2"
 BB_NUMBER_THREADS = "2"
 
-DISTRO = "angstrom-next"
+DISTRO = "angstrom"
 # Set DEPLOY_DIR outside of TMPDIR
 
 DEPLOY_DIR = "${TMPDIR}/../../deploy/${TCLIBC}"


### PR DESCRIPTION
The DISTRO in meta-angstrom[next] changed from "angstrom-next" to "angstrom",
therefore adjust local.conf to match.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>